### PR TITLE
deps: replace Pygments with Rouge; fix fenced code blocks and highlighting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'jekyll'
 gem 'kramdown'
+gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
+    rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.18)
     timers (4.0.4)
@@ -69,6 +70,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   kramdown
+  rouge
 
 BUNDLED WITH
    1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ source: content
 permalink: /:categories/:year/:month/:day/:title
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
 
 # Themes are encouraged to use these universal variables
 # so be sure to set them if your theme uses them.
@@ -13,7 +12,7 @@ pygments: true
 title : Style Guide
 tagline: 
 author :
-  name : Punch Through Design
+  name : Punch Through
   github : PunchThrough
   twitter : PunchThrough
 environment: development
@@ -27,8 +26,9 @@ environment: development
 #
 
 markdown: kramdown
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 
 production_url : http://punchthrough.github.io/styleguide
 

--- a/_prod_config.yml
+++ b/_prod_config.yml
@@ -5,7 +5,6 @@ source: content
 permalink: /:categories/:year/:month/:day/:title
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
 
 # Themes are encouraged to use these universal variables
 # so be sure to set them if your theme uses them.
@@ -13,7 +12,7 @@ pygments: true
 title : Style Guide
 tagline: 
 author :
-  name : Punch Through Design
+  name : Punch Through
   github : PunchThrough
   twitter : PunchThrough
 environment: production
@@ -27,8 +26,9 @@ environment: production
 #
 
 markdown: kramdown
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables"]
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 
 production_url : http://punchthrough.github.io/styleguide
 


### PR DESCRIPTION
Some stuff broke in the Obj-C guide. This fixes code blocks that broke when we installed Kramdown.